### PR TITLE
Fix error with pointer comparison

### DIFF
--- a/src/xtests.core.cpp
+++ b/src/xtests.core.cpp
@@ -2733,7 +2733,7 @@ namespace
             virtual void onDefect(void* /* reporterParam */, char const* message, char const* qualifier, int /* verbosity */)
             {
                 if( NULL != qualifier &&
-                    '\0' == qualifier)
+                    '\0' == *qualifier)
                 {
                     qualifier = NULL;
                 }


### PR DESCRIPTION
Not 100% sure if this is a bug.
The compiler complained.

Error: GNU C 7.4.0:
/home/mikkoi/other/own_github/xTests/src/xtests.core.cpp:2736:29:` warning: comparison between pointer and zero character constant [-Wpointer-compare]
                     '\0' == qualifier)
                             ^~~~~~~~~
/home/mikkoi/other/own_github/xTests/src/xtests.core.cpp:2736:29: note: did you mean to dereference the pointer?
```

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>